### PR TITLE
Add Observers::Set#{once,off} methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Because of this issue, I decided to create a gem that encapsulates the pattern w
     - [Using a callable as an observer](#using-a-callable-as-an-observer)
     - [Calling the observers](#calling-the-observers)
     - [Notifying observers without marking them as changed](#notifying-observers-without-marking-them-as-changed)
-    - [Perform observers only once](#perform-observers-only-once)
+    - [Defining observers that execute only once](#defining-observers-that-execute-only-once)
       - [`observers.attach(*args, perform_once: true)`](#observersattachargs-perform_once-true)
       - [`observers.once(event:, call:, ...)`](#observersonceevent-call-)
     - [Detaching observers](#detaching-observers)
@@ -311,7 +311,7 @@ If you use the methods `#notify!` or `#call!` you won't need to mark observers w
 
 [⬆️ &nbsp; Back to Top](#table-of-contents-)
 
-### Perform observers only once
+### Defining observers that execute only once
 
 There are two ways to attach an observer and define it to be performed only once.
 
@@ -346,7 +346,7 @@ order.cancel!         # Nothing will happen because there aren't observers.
 
 #### `observers.once(event:, call:, ...)`
 
-The second way to achieve this is using `observers.once()` that has the same API of [`observers.on()`](#using-a-callable-as-an-observer). But, it will remove the observer after its execution.
+The second way to achieve this is using `observers.once()` that has the same API of [`observers.on()`](#using-a-callable-as-an-observer). But the difference of the `#once()` method is that it will remove the observer after its execution.
 
 ```ruby
 class Order

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Because of this issue, I decided to create a gem that encapsulates the pattern w
     - [Using a callable as an observer](#using-a-callable-as-an-observer)
     - [Calling the observers](#calling-the-observers)
     - [Notifying observers without marking them as changed](#notifying-observers-without-marking-them-as-changed)
+    - [Perform observers only once](#perform-observers-only-once)
+      - [`observers.attach(*args, perform_once: true)`](#observersattachargs-perform_once-true)
+      - [`observers.once(event:, call:, ...)`](#observersonceevent-call-)
+    - [Detaching observers](#detaching-observers)
     - [ActiveRecord and ActiveModel integrations](#activerecord-and-activemodel-integrations)
       - [notify_observers_on()](#notify_observers_on)
       - [notify_observers()](#notify_observers)
@@ -109,7 +113,7 @@ end
 order = Order.new
 #<Order:0x00007fb5dd8fce70 @code="X0o9yf1GsdQFvLR4", @status=:draft>
 
-order.observers.attach(OrderEvents)          # attaching multiple observers. e.g. observers.attach(A, B, C)
+order.observers.attach(OrderEvents)  # attaching multiple observers. e.g. observers.attach(A, B, C)
 # <#Micro::Observers::Set @subject=#<Order:0x00007fb5dd8fce70> @subject_changed=false @subscribers=[OrderEvents]>
 
 order.canceled?
@@ -122,7 +126,7 @@ order.cancel!
 order.canceled?
 # true
 
-order.observers.detach(OrderEvents)          # detaching multiple observers. e.g. observers.detach(A, B, C)
+order.observers.detach(OrderEvents)  # detaching multiple observers. e.g. observers.detach(A, B, C)
 # <#Micro::Observers::Set @subject=#<Order:0x00007fb5dd8fce70> @subject_changed=false @subscribers=[]>
 
 order.canceled?
@@ -286,12 +290,12 @@ class Order
   end
 end
 
-OrderCancellation = -> (order) { puts "The order #(#{order.object_id}) has been canceled." }
+NotifyAfterCancel = -> (order) { puts "The order #(#{order.object_id}) has been canceled." }
 
 order = Order.new
-order.observers.attach(OrderCancellation)
+order.observers.attach(NotifyAfterCancel)
 order.cancel!
-# The message below will be printed by the observer (OrderCancellation):
+# The message below will be printed by the observer (NotifyAfterCancel):
 # The order #(70196221441820) has been canceled.
 ```
 
@@ -307,6 +311,106 @@ If you use the methods `#notify!` or `#call!` you won't need to mark observers w
 
 [⬆️ &nbsp; Back to Top](#table-of-contents-)
 
+### Perform observers only once
+
+There are two ways to attach an observer and define it to be performed only once.
+
+The first way to do this is passing the `perform_once: true` option to the `observers.attach()` method. e.g.
+
+#### `observers.attach(*args, perform_once: true)`
+
+```ruby
+class Order
+  include Micro::Observers
+
+  def cancel!
+    observers.notify!(:canceled)
+  end
+end
+
+module OrderNotifications
+  def self.canceled(order)
+    puts "The order #(#{order.object_id}) has been canceled."
+  end
+end
+
+order = Order.new
+order.observers.attach(OrderNotifications, perform_once: true) # you can also pass an array of observers with this option
+
+order.observers.some? # true
+order.cancel!         # The order #(70291642071660) has been canceled.
+
+order.observers.some? # false
+order.cancel!         # Nothing will happen because there aren't observers.
+```
+
+#### `observers.once(event:, call:, ...)`
+
+The second way to achieve this is using `observers.once()` that has the same API of [`observers.on()`](#using-a-callable-as-an-observer). But, it will remove the observer after its execution.
+
+```ruby
+class Order
+  include Micro::Observers
+
+  def cancel!
+    observers.notify!(:canceled)
+  end
+end
+
+module NotifyAfterCancel
+  def self.call(event)
+    puts "The order #(#{event.subject.object_id}) has been canceled."
+  end
+end
+
+order = Order.new
+order.observers.once(event: :canceled, call: NotifyAfterCancel)
+
+order.observers.some? # true
+order.cancel!         # The order #(70301497466060) has been canceled.
+
+order.observers.some? # false
+order.cancel!         # Nothing will happen because there aren't observers.
+```
+
+[⬆️ &nbsp; Back to Top](#table-of-contents-)
+
+### Detaching observers
+
+As shown in the first example, you can use the `observers.detach()` to remove observers.
+
+But, there is an alternative method to remove observer objects or remove callables by their event names. The method to do this is: `observers.off()`.
+
+```ruby
+class Order
+  include Micro::Observers
+end
+
+NotifyAfterCancel = -> {}
+
+module OrderNotifications
+  def self.canceled(_order)
+  end
+end
+
+order = Order.new
+order.observers.on(event: :canceled, call: NotifyAfterCancel)
+order.observers.attach(OrderNotifications)
+
+order.observers.some? # true
+order.observers.count # 2
+
+order.observers.off(:canceled) # removing the callable (NotifyAfterCancel).
+order.observers.some? # true
+order.observers.count # 1
+
+order.observers.off(OrderNotifications)
+order.observers.some? # false
+order.observers.count # 0
+```
+
+[⬆️ &nbsp; Back to Top](#table-of-contents-)
+
 ### ActiveRecord and ActiveModel integrations
 
 To make use of this feature you need to require an additional module.
@@ -317,7 +421,6 @@ gem 'u-observers', require: 'u-observers/for/active_record'
 ```
 
 This feature will expose modules that could be used to add macros (static methods) that were designed to work with `ActiveModel`/`ActiveRecord` callbacks. e.g:
-
 
 #### notify_observers_on()
 

--- a/lib/micro/observers/broadcast.rb
+++ b/lib/micro/observers/broadcast.rb
@@ -8,33 +8,35 @@ module Micro
     module Broadcast
       extend self
 
-      def call(data, subject, event_names, subscribers)
-        sweep_marker = ::Set.new
+      def call(subscribers, subject, data, event_names)
+        subscribers_list = subscribers.list
+        subscribers_to_be_deleted = ::Set.new
 
-        event_names.each(&BroadcastWith[subscribers, subject, data, sweep_marker])
+        event_names.each(&BroadcastWith[subscribers_list, subject, data, subscribers_to_be_deleted])
 
-        sweep_marker.each { |subscriber| subscribers.delete(subscriber) }
+        subscribers_to_be_deleted.each { |subscriber| subscribers_list.delete(subscriber) }
       end
 
       private
 
-        BroadcastWith = -> (subscribers, subject, data, sweep_marker) do
+        BroadcastWith = -> (subscribers, subject, data, subscribers_to_be_deleted) do
           -> (event_name) do
             subscribers.each do |subscriber|
-              notified = Notify.(subscriber, event_name, subject, data)
+              notified = NotifySubscriber.(subscriber, subject, data, event_name)
+              perform_once = subscriber[3]
 
-              sweep_marker << subscriber if notified && subscriber[3]
+              subscribers_to_be_deleted.add(subscriber) if notified && perform_once
             end
           end
         end
 
-        Notify = -> (subscriber, event_name, subject, data) do
-          NotifyObserver.(subscriber, event_name, subject, data) ||
-          NotifyCallable.(subscriber, event_name, subject, data) ||
+        NotifySubscriber = -> (subscriber, subject, data, event_name) do
+          NotifyObserver.(subscriber, subject, data, event_name) ||
+          NotifyCallable.(subscriber, subject, data, event_name) ||
           false
         end
 
-        NotifyObserver = -> (subscriber, event_name, subject, data) do
+        NotifyObserver = -> (subscriber, subject, data, event_name) do
           strategy, observer, context = subscriber
 
           return unless strategy == :observer && observer.respond_to?(event_name)
@@ -47,12 +49,12 @@ module Micro
           true
         end
 
-        NotifyCallable = -> (subscriber, event_name, subject, data) do
-          strategy, observer, opt = subscriber
+        NotifyCallable = -> (subscriber, subject, data, event_name) do
+          strategy, observer, options = subscriber
 
           return unless strategy == :callable && observer == event_name
 
-          callable, with, context = opt[0], opt[1], opt[2]
+          callable, with, context = options[0], options[1], options[2]
 
           return callable.call(with) if with && !with.is_a?(Proc)
 
@@ -62,6 +64,8 @@ module Micro
 
           true
         end
+
+      private_constant :BroadcastWith, :NotifySubscriber, :NotifyCallable, :NotifyObserver
     end
 
     private_constant :Broadcast

--- a/lib/micro/observers/broadcast.rb
+++ b/lib/micro/observers/broadcast.rb
@@ -75,5 +75,6 @@ module Micro
       private_constant :EventHandler, :NotifyObserver, :NotifyCallable
     end
 
+    private_constant :Broadcast
   end
 end

--- a/lib/micro/observers/for/active_model.rb
+++ b/lib/micro/observers/for/active_model.rb
@@ -18,7 +18,7 @@ module Micro
           end
 
           def notify_observers_on(*callback_methods)
-            Utils::Arrays.flatten_and_compact(callback_methods).each do |callback_method|
+            Utils::Arrays.fetch_from_args(callback_methods).each do |callback_method|
               self.public_send(callback_method, &notify_observers!([callback_method]))
             end
           end

--- a/lib/micro/observers/set.rb
+++ b/lib/micro/observers/set.rb
@@ -70,7 +70,7 @@ module Micro
       def inspect
         subs = @subscribers.to_inspect
 
-        '<#%s @subject=%s @subject_changed=%p @subscribers=%p>' % [self.class, @subject, @subject_changed, subs]
+        '#<%s @subject=%s @subject_changed=%p @subscribers=%p>' % [self.class, @subject, @subject_changed, subs]
       end
 
       private

--- a/lib/micro/observers/set.rb
+++ b/lib/micro/observers/set.rb
@@ -11,7 +11,6 @@ module Micro
       def initialize(subject, subscribers: nil)
         @subject = subject
         @subject_changed = false
-
         @subscribers = Subscribers.new(subscribers)
       end
 

--- a/lib/micro/observers/set.rb
+++ b/lib/micro/observers/set.rb
@@ -88,7 +88,7 @@ module Micro
         def broadcast(event_names, data)
           return self if none?
 
-          Broadcast.call(data, @subject, event_names, @subscribers.relation)
+          Broadcast.call(@subscribers, @subject, data, event_names)
 
           self
         end

--- a/lib/micro/observers/subscribers.rb
+++ b/lib/micro/observers/subscribers.rb
@@ -98,5 +98,6 @@ module Micro
       private_constant :GetObserver, :MapObserver, :MapObserverWithoutContext
     end
 
+    private_constant :Subscribers
   end
 end

--- a/lib/micro/observers/subscribers.rb
+++ b/lib/micro/observers/subscribers.rb
@@ -6,14 +6,18 @@ module Micro
     class Subscribers
       EqualTo = -> (observer) { -> subscriber { GetObserver[subscriber] == observer } }
       GetObserver = -> subscriber { subscriber[0] == :observer ? subscriber[1] : subscriber[2][0] }
-      MapObserver = -> (observer, options) { [:observer, observer, options[:context]] }
-      MapObserverWithoutContext = -> observer { MapObserver[observer, Utils::EMPTY_HASH] }
+      MapObserver = -> (observer, options, once) { [:observer, observer, options[:context], once] }
+      MapObserverWithoutContext = -> observer { MapObserver[observer, Utils::EMPTY_HASH, false] }
 
       attr_reader :relation
 
       def initialize(arg)
         array = Utils::Arrays.flatten_and_compact(arg.kind_of?(Array) ? arg : [])
         @relation = array.map(&MapObserverWithoutContext)
+      end
+
+      def to_inspect
+        none? ? @relation : @relation.map(&GetObserver)
       end
 
       def count
@@ -31,8 +35,10 @@ module Micro
       def attach(args)
         options = args.last.is_a?(Hash) ? args.pop : Utils::EMPTY_HASH
 
+        once = options.frozen? ? false : options.delete(:perform_once)
+
         Utils::Arrays.flatten_and_compact(args).each do |observer|
-          @relation << MapObserver[observer, options] unless include?(observer)
+          @relation << MapObserver[observer, options, once] unless include?(observer)
         end
 
         true
@@ -40,27 +46,56 @@ module Micro
 
       def detach(args)
         Utils::Arrays.flatten_and_compact(args).each do |observer|
-          @relation.delete_if(&EqualTo[observer])
+          delete_observer(observer)
         end
 
         true
       end
 
       def on(options)
-        event, callable, with, context = options[:event], options[:call], options[:with], options[:context]
-
-        return true unless event.is_a?(Symbol) && callable.respond_to?(:call)
-
-        @relation << [:callable, event, [callable, with, context]] unless include?(callable)
-
-        true
+        on!(options, once: false)
       end
 
-      def to_inspect
-        none? ? @relation : @relation.map(&GetObserver)
+      EventNameToCall = -> event_name { -> subscriber { subscriber[0] == :callable && subscriber[1] == event_name } }
+
+      def off(args)
+        Utils::Arrays.flatten_and_compact(args).each do |value|
+          if value.is_a?(Symbol)
+            @relation.delete_if(&EventNameToCall[value])
+          else
+            delete_observer(value)
+          end
+        end
       end
 
-      private_constant :EqualTo, :GetObserver, :MapObserver, :MapObserverWithoutContext
+      def once(options)
+        on!(options, once: true)
+      end
+
+      def delete(observers)
+        return if observers.empty?
+
+        observers.each { |observer| @relation.delete(observer) }
+      end
+
+      private
+
+        def delete_observer(observer)
+          @relation.delete_if(&EqualTo[observer])
+        end
+
+        def on!(options, once:)
+          event, callable, with, context = options[:event], options[:call], options[:with], options[:context]
+
+          return true unless event.is_a?(Symbol) && callable.respond_to?(:call)
+
+          @relation << [:callable, event, [callable, with, context], once] unless include?(callable)
+
+          true
+        end
+
+      private_constant :EqualTo, :EventNameToCall
+      private_constant :GetObserver, :MapObserver, :MapObserverWithoutContext
     end
 
   end

--- a/lib/micro/observers/subscribers.rb
+++ b/lib/micro/observers/subscribers.rb
@@ -13,26 +13,26 @@ module Micro
         end
       end
 
-      attr_reader :relation
+      attr_reader :list
 
       def initialize(arg)
-        @relation = arg.is_a?(Array) ? MapObserversToInitialize[arg] : []
+        @list = arg.is_a?(Array) ? MapObserversToInitialize[arg] : []
       end
 
       def to_inspect
-        none? ? @relation : @relation.map(&GetObserver)
+        none? ? @list : @list.map(&GetObserver)
       end
 
       def count
-        @relation.size
+        @list.size
       end
 
       def none?
-        @relation.empty?
+        @list.empty?
       end
 
       def include?(subscriber)
-        @relation.any?(&EqualTo[subscriber])
+        @list.any?(&EqualTo[subscriber])
       end
 
       def attach(args)
@@ -41,7 +41,7 @@ module Micro
         once = options.frozen? ? false : options.delete(:perform_once)
 
         Utils::Arrays.fetch_from_args(args).each do |observer|
-          @relation << MapObserver[observer, options, once] unless include?(observer)
+          @list << MapObserver[observer, options, once] unless include?(observer)
         end
 
         true
@@ -68,7 +68,7 @@ module Micro
       def off(args)
         Utils::Arrays.fetch_from_args(args).each do |value|
           if value.is_a?(Symbol)
-            @relation.delete_if(&EventNameToCall[value])
+            @list.delete_if(&EventNameToCall[value])
           else
             delete_observer(value)
           end
@@ -78,7 +78,7 @@ module Micro
       private
 
         def delete_observer(observer)
-          @relation.delete_if(&EqualTo[observer])
+          @list.delete_if(&EqualTo[observer])
         end
 
         def on!(options, once:)
@@ -86,7 +86,7 @@ module Micro
 
           return true unless event.is_a?(Symbol) && callable.respond_to?(:call)
 
-          @relation << [:callable, event, [callable, with, context], once] unless include?(callable)
+          @list << [:callable, event, [callable, with, context], once] unless include?(callable)
 
           true
         end

--- a/lib/micro/observers/subscribers.rb
+++ b/lib/micro/observers/subscribers.rb
@@ -56,6 +56,10 @@ module Micro
         on!(options, once: false)
       end
 
+      def once(options)
+        on!(options, once: true)
+      end
+
       EventNameToCall = -> event_name { -> subscriber { subscriber[0] == :callable && subscriber[1] == event_name } }
 
       def off(args)
@@ -66,16 +70,6 @@ module Micro
             delete_observer(value)
           end
         end
-      end
-
-      def once(options)
-        on!(options, once: true)
-      end
-
-      def delete(observers)
-        return if observers.empty?
-
-        observers.each { |observer| @relation.delete(observer) }
       end
 
       private

--- a/lib/micro/observers/utils.rb
+++ b/lib/micro/observers/utils.rb
@@ -7,7 +7,13 @@ module Micro
       EMPTY_HASH = {}.freeze
 
       module Arrays
+        def self.fetch_from_args(args)
+          args.size == 1 && (first = args[0]).is_a?(::Array) ? first : args
+        end
+
         def self.flatten_and_compact(value)
+          return [] unless value
+
           array = Array(value).flatten
           array.compact!
           array

--- a/test/micro/observers/set/detach_test.rb
+++ b/test/micro/observers/set/detach_test.rb
@@ -72,5 +72,56 @@ module Micro::Observers
 
       assert_predicate(StreamInMemory.history, :empty?)
     end
+
+    def test_the_detaching_using_off
+      person = Person.new(name: 'Rodrigo')
+
+      # --
+
+      person.observers.attach(PersonNamePrinter)
+      person.observers.on(event: :name_has_been_changed, call: PrintPersonName)
+
+      assert_equal(2, person.observers.count)
+
+      person.observers.off(:name_has_been_changed)
+      assert_equal(1, person.observers.count)
+
+      assert person.observers.include?(PersonNamePrinter)
+
+      person.observers.off(PersonNamePrinter)
+
+      assert_equal(0, person.observers.count)
+
+      # --
+
+      person.observers.attach(PersonNamePrinter)
+      person.observers.on(event: :name_has_been_changed, call: PrintPersonName)
+
+      assert_equal(2, person.observers.count)
+
+      person.observers.off(:name_has_been_changed, PersonNamePrinter)
+      assert_equal(0, person.observers.count)
+
+      # --
+
+      person.observers.on(event: :name_has_been_changed, call: PrintPersonName)
+
+      assert_equal(1, person.observers.count)
+
+      person.observers.off([:name_has_been_changed])
+
+      assert_equal(0, person.observers.count)
+
+      # --
+
+      person.observers.attach(PersonNamePrinter)
+      person.observers.on(event: :name_has_been_changed, call: PrintPersonName)
+
+      assert_equal(2, person.observers.count)
+
+      person.observers.off([:name_has_been_changed, PersonNamePrinter])
+
+      assert_equal(0, person.observers.count)
+    end
   end
 end

--- a/test/micro/observers/set/inspect_test.rb
+++ b/test/micro/observers/set/inspect_test.rb
@@ -14,7 +14,7 @@ module Micro::Observers
       observers = Set.new('hello', subscribers: [PrintWord, PrintUpcasedWord])
 
       assert_match(
-        /<#Micro::Observers::Set @subject=hello @subject_changed=false @subscribers=\[#<Proc:0x.+\/.+\/inspect_test.rb:5 \(lambda\)>, .+PrintUpcasedWord\]>/,
+        /#<Micro::Observers::Set @subject=hello @subject_changed=false @subscribers=\[#<Proc:0x.+\/.+\/inspect_test.rb:5 \(lambda\)>, .+PrintUpcasedWord\]>/,
         observers.inspect
       )
     end
@@ -23,7 +23,7 @@ module Micro::Observers
       observers = Set.new('hello')
 
       assert_match(
-        /<#Micro::Observers::Set @subject=hello @subject_changed=false @subscribers=\[\]>/,
+        /#<Micro::Observers::Set @subject=hello @subject_changed=false @subscribers=\[\]>/,
         observers.inspect
       )
     end


### PR DESCRIPTION
**Features:**
- [x] Allow attaching an observer with the `:perform_once` option. e.g: `obj.observers.attach(MyObserver, perform_once: true)`
- [x] Allow attaching a callable using `observers.once()` to make just a single notification to it, it will be auto removed after its execution.
- [x] Add `observers.off()` that will allow detaching observer objects or callables by their event names (`:symbol`).

---

- [x] Update README.md
- [x] Update README.pt-BR.md