### PR TITLE
docs: document the no-breaking-API-changes policy (READMEs + CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,25 @@
 
 Notes for AI assistants working in `u-observers`.
 
+## Golden rule: no breaking API changes — ever
+
+`u-observers` is a dependency-free gem that many projects rely on, directly or
+transitively. **Its public API and runtime contracts won't break.** Every
+change must keep existing code working.
+
+Unlike `u-attributes`, this is *not* because it's a runtime dependency of
+`u-case` (it isn't — `u-case` depends on `kind` and `u-attributes`). The
+commitment stands on its own: the gem's role is to remain a stable,
+backward-compatible foundation for everything that depends on it.
+
+Major version bumps are reserved for dependency-floor changes (dropping a Ruby
+or Rails version from the supported matrix) per SemVer. They do **not** signal
+a behavior break.
+
+If a task as stated would require a breaking change to honor it, stop and
+surface that — propose a backward-compatible path, or flag that the request
+can't be satisfied without violating this rule. Don't ship the break.
+
 ## How to work in this repo
 
 ### 1. Think before coding

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@
   <img src="https://img.shields.io/badge/Rails%20%3E%3D%206.0%2C%20%3C%3D%20Edge-rails.svg?colorA=444&colorB=333" alt="Rails">
 </p>
 
+> [!IMPORTANT]
+> **No breaking API changes — ever.** `u-observers` is a dependency-free gem that many projects rely on (directly or transitively). Its role is to remain a stable, backward-compatible foundation — every change keeps existing code working.
+>
+> Major version bumps signal only that a Ruby or Rails version was dropped from the supported matrix — per SemVer, a dependency-floor change. Your code keeps working.
+
 This gem implements the observer pattern [[1]](https://en.wikipedia.org/wiki/Observer_pattern)[[2]](https://refactoring.guru/design-patterns/observer) (also known as publish/subscribe). It provides a simple mechanism for one object to inform a set of interested third-party objects when its state changes.
 
 Ruby's standard library [has an abstraction](https://ruby-doc.org/stdlib-2.7.1/libdoc/observer/rdoc/Observable.html) that enables you to use this pattern. But its design can conflict with other mainstream libraries, like the [`ActiveModel`/`ActiveRecord`](https://api.rubyonrails.org/classes/ActiveModel/Dirty.html#method-i-changed), which also has the [`changed`](https://ruby-doc.org/stdlib-2.7.1/libdoc/observer/rdoc/Observable.html#method-i-changed) method. In this case, the behavior of the Stdlib will be compromised.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -27,6 +27,11 @@
   <img src="https://img.shields.io/badge/Rails%20%3E%3D%206.0%2C%20%3C%3D%20Edge-rails.svg?colorA=444&colorB=333" alt="Rails">
 </p>
 
+> [!IMPORTANT]
+> **Nenhuma mudança que quebre a API — nunca.** `u-observers` é uma gem sem dependências da qual muitos projetos dependem (direta ou transitivamente). Seu papel é permanecer uma base estável e retrocompatível — toda mudança mantém o código existente funcionando.
+>
+> Saltos de versão major sinalizam apenas que uma versão de Ruby ou Rails foi removida da matriz suportada — pela SemVer, uma mudança no piso de dependências. Seu código continua funcionando.
+
 Esta gem implementa o padrão observer[[1]](https://en.wikipedia.org/wiki/Observer_pattern)[[2]](https://refactoring.guru/design-patterns/observer) (também conhecido como publicar/assinar). Ela fornece um mecanismo simples para um objeto informar um conjunto de objetos de terceiros interessados ​​quando seu estado muda.
 
 A biblioteca padrão do Ruby [tem uma abstração](https://ruby-doc.org/stdlib-2.7.1/libdoc/observer/rdoc/Observable.html) que permite usar esse padrão, mas seu design pode entrar em conflito com outras bibliotecas convencionais, como [`ActiveModel`/`ActiveRecord`](https://api.rubyonrails.org/classes/ActiveModel/Dirty.html#method-i-changed), que também tem o método [`changed`](https://ruby-doc.org/stdlib-2.7.1/libdoc/observer/rdoc/Observable.html#method-i-changed). Nesse caso, o comportamento ficaria comprometido por conta dessa sobrescrita de métodos.


### PR DESCRIPTION
Documents `u-observers`' **"No breaking API changes — ever"** policy, mirroring [`u-attributes`](https://github.com/serradura/u-attributes).

### Changes
1. **READMEs (EN + pt-BR)** — adds the `> [!IMPORTANT]` API-stability callout right below the badges.
2. **CLAUDE.md** — adds a matching "Golden rule" section so the policy is documented for AI assistants too.

### Rationale adapted (not copied verbatim)
The u-attributes wording justifies the policy by being a *runtime dependency of `u-case`*. That does **not** apply here — `u-case` depends on `kind` and `u-attributes`, not `u-observers`, and `u-observers` is itself dependency-free. So the wording is reframed: a dependency-free gem many projects rely on (directly or transitively), committing to a stable, backward-compatible public API; major bumps only drop a Ruby/Rails version from the supported matrix.

Docs-only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)