### PR TITLE
Add notify_observers!: declarative class-level observers for AR/AM callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,40 @@ end
 # Title: Hello world (from: example #6)
 ```
 
+You can also bind the observers to the model **at the class level** with `with:`, so you don't have to `attach` them on every instance. Use `context:` to forward a context to those observers, and pass any extra option (e.g. `on:`) straight through to the underlying callback.
+
+```ruby
+class Post < ActiveRecord::Base
+  include ::Micro::Observers::For::ActiveRecord
+
+  # Attach TitlePrinter (and TitlePrinterWithContext) on every after_commit
+  # triggered by an update — no per-instance `observers.attach` needed.
+  notify_observers_on(
+    :after_commit,
+    with: [TitlePrinter, TitlePrinterWithContext],
+    context: { from: 'class-level' },
+    on: :update
+  )
+
+  # Equivalent to:
+  #
+  # after_commit(on: :update) do |record|
+  #   record.observers.attach(TitlePrinter, TitlePrinterWithContext, context: { from: 'class-level' })
+  #   record.observers.subject_changed!
+  #   record.observers.notify(:after_commit)
+  # end
+end
+
+Post.transaction { Post.create(title: 'Hello world') } # nothing — `on: :update`
+
+post = Post.first
+Post.transaction { post.update(title: 'Hello again') }
+# Title: Hello again
+# Title: Hello again (from: class-level)
+```
+
+> **Note**: `with:` accepts a single observer or an array. Without it, `notify_observers_on` keeps its original behavior (it only wires the callback to a broadcast; you attach observers per instance).
+
 [⬆️ &nbsp; Back to Top](#table-of-contents-)
 
 #### `.notify_observers()`

--- a/README.md
+++ b/README.md
@@ -591,6 +591,23 @@ Post.transaction { post.update(title: 'Hello again') }
 
 > **Note**: `event:` and `with:` are required (`with:` accepts a single observer or an array). Without observers to attach, use `notify_observers_on` instead.
 
+The declared observers are introspectable and detachable at the class level:
+
+```ruby
+Post.observers_to_notify
+# { after_commit: [TitlePrinter, TitlePrinterWithContext] }
+
+# Stop notifying a given observer (from every callback, or scope it with `from:`)
+Post.detach_observers_to_notify(TitlePrinterWithContext)
+# { after_commit: [TitlePrinter] }
+
+Post.detach_observers_to_notify(TitlePrinter, from: :after_commit)
+# {}
+
+# With no observers, clears the callback(s) entirely:
+Post.detach_observers_to_notify(from: :after_commit)
+```
+
 [⬆️ &nbsp; Back to Top](#table-of-contents-)
 
 #### `.notify_observers()`

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Because of this issue, I decided to create a gem that encapsulates the pattern w
     - [Detaching observers](#detaching-observers)
     - [ActiveRecord and ActiveModel integrations](#activerecord-and-activemodel-integrations)
       - [`.notify_observers_on()`](#notify_observers_on)
+      - [`.notify_observers_event()`](#notify_observers_event)
       - [`.notify_observers()`](#notify_observers)
   - [Development](#development)
   - [Contributing](#contributing)
@@ -552,7 +553,11 @@ end
 # Title: Hello world (from: example #6)
 ```
 
-You can also bind the observers to the model **at the class level** with `with:`, so you don't have to `attach` them on every instance. Use `context:` to forward a context to those observers, and pass any extra option (e.g. `on:`) straight through to the underlying callback.
+[⬆️ &nbsp; Back to Top](#table-of-contents-)
+
+#### `.notify_observers_event()`
+
+While `notify_observers_on` only wires the callback to a broadcast (you still `attach` the observers on every instance), `notify_observers_event` also **binds the observers to the model at the class level** through the required `with:` option — so you never call `observers.attach` yourself. Use `context:` to forward a context to those observers, and pass any extra option (e.g. `on:`) straight through to the underlying callback.
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -560,7 +565,7 @@ class Post < ActiveRecord::Base
 
   # Attach TitlePrinter (and TitlePrinterWithContext) on every after_commit
   # triggered by an update — no per-instance `observers.attach` needed.
-  notify_observers_on(
+  notify_observers_event(
     :after_commit,
     with: [TitlePrinter, TitlePrinterWithContext],
     context: { from: 'class-level' },
@@ -584,7 +589,7 @@ Post.transaction { post.update(title: 'Hello again') }
 # Title: Hello again (from: class-level)
 ```
 
-> **Note**: `with:` accepts a single observer or an array. Without it, `notify_observers_on` keeps its original behavior (it only wires the callback to a broadcast; you attach observers per instance).
+> **Note**: `with:` accepts a single observer or an array, and is required (without observers to attach, use `notify_observers_on` instead).
 
 [⬆️ &nbsp; Back to Top](#table-of-contents-)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Because of this issue, I decided to create a gem that encapsulates the pattern w
     - [Detaching observers](#detaching-observers)
     - [ActiveRecord and ActiveModel integrations](#activerecord-and-activemodel-integrations)
       - [`.notify_observers_on()`](#notify_observers_on)
-      - [`.notify_observers_event()`](#notify_observers_event)
+      - [`.notify_observers!()`](#attaching-observers-at-the-class-level-notify_observers)
       - [`.notify_observers()`](#notify_observers)
   - [Development](#development)
   - [Contributing](#contributing)
@@ -555,9 +555,9 @@ end
 
 [⬆️ &nbsp; Back to Top](#table-of-contents-)
 
-#### `.notify_observers_event()`
+#### Attaching observers at the class level (`.notify_observers!()`)
 
-While `notify_observers_on` only wires the callback to a broadcast (you still `attach` the observers on every instance), `notify_observers_event` also **binds the observers to the model at the class level** through the required `with:` option — so you never call `observers.attach` yourself. Use `context:` to forward a context to those observers, and pass any extra option (e.g. `on:`) straight through to the underlying callback.
+While `notify_observers_on` only wires the callback to a broadcast (you still `attach` the observers on every instance), `notify_observers!` also **binds the observers to the model at the class level** through the required `with:` option — so you never call `observers.attach` yourself. The `event:` option names the callback to hook; use `context:` to forward a context to those observers, and pass any extra option (e.g. `on:`) straight through to the underlying callback.
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -565,11 +565,11 @@ class Post < ActiveRecord::Base
 
   # Attach TitlePrinter (and TitlePrinterWithContext) on every after_commit
   # triggered by an update — no per-instance `observers.attach` needed.
-  notify_observers_event(
-    :after_commit,
+  notify_observers!(
+    on: :update,
     with: [TitlePrinter, TitlePrinterWithContext],
-    context: { from: 'class-level' },
-    on: :update
+    event: :after_commit,
+    context: { from: 'class-level' }
   )
 
   # Equivalent to:
@@ -589,7 +589,7 @@ Post.transaction { post.update(title: 'Hello again') }
 # Title: Hello again (from: class-level)
 ```
 
-> **Note**: `with:` accepts a single observer or an array, and is required (without observers to attach, use `notify_observers_on` instead).
+> **Note**: `event:` and `with:` are required (`with:` accepts a single observer or an array). Without observers to attach, use `notify_observers_on` instead.
 
 [⬆️ &nbsp; Back to Top](#table-of-contents-)
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -592,6 +592,23 @@ Post.transaction { post.update(title: 'Hello again') }
 
 > **Nota**: `event:` e `with:` são obrigatórios (`with:` aceita um único *observer* ou um array). Sem *observers* para anexar, use o `notify_observers_on`.
 
+Os *observers* declarados são inspecionáveis e removíveis no nível da classe:
+
+```ruby
+Post.observers_to_notify
+# { after_commit: [TitlePrinter, TitlePrinterWithContext] }
+
+# Para de notificar um dado observer (de todos os callbacks, ou use `from:` para limitar)
+Post.detach_observers_to_notify(TitlePrinterWithContext)
+# { after_commit: [TitlePrinter] }
+
+Post.detach_observers_to_notify(TitlePrinter, from: :after_commit)
+# {}
+
+# Sem observers, remove o(s) callback(s) por completo:
+Post.detach_observers_to_notify(from: :after_commit)
+```
+
 [⬆️ Voltar para o índice](#índice-)
 
 #### `.notify_observers()`

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -553,6 +553,40 @@ end
 # Title: Hello world (de: exemplo # 6)
 ```
 
+Você também pode vincular os *observers* ao modelo **no nível da classe** com `with:`, evitando ter que chamar `attach` em cada instância. Use `context:` para encaminhar um contexto para esses *observers*, e passe qualquer opção extra (por exemplo, `on:`) diretamente para o callback subjacente.
+
+```ruby
+class Post < ActiveRecord::Base
+  include ::Micro::Observers::For::ActiveRecord
+
+  # Anexa TitlePrinter (e TitlePrinterWithContext) em todo after_commit
+  # disparado por um update — sem precisar de `observers.attach` por instância.
+  notify_observers_on(
+    :after_commit,
+    with: [TitlePrinter, TitlePrinterWithContext],
+    context: { from: 'class-level' },
+    on: :update
+  )
+
+  # Equivalente a:
+  #
+  # after_commit(on: :update) do |record|
+  #   record.observers.attach(TitlePrinter, TitlePrinterWithContext, context: { from: 'class-level' })
+  #   record.observers.subject_changed!
+  #   record.observers.notify(:after_commit)
+  # end
+end
+
+Post.transaction { Post.create(title: 'Hello world') } # nada — `on: :update`
+
+post = Post.first
+Post.transaction { post.update(title: 'Hello again') }
+# Title: Hello again
+# Title: Hello again (de: class-level)
+```
+
+> **Nota**: `with:` aceita um único *observer* ou um array. Sem ele, o `notify_observers_on` mantém seu comportamento original (apenas conecta o callback a um broadcast; você anexa os *observers* por instância).
+
 [⬆️ Voltar para o índice](#índice-)
 
 #### `.notify_observers()`

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -59,6 +59,7 @@ Por causa desse problema, decidi criar uma gem que encapsula o padrão sem alter
     - [Desanexando observers](#desanexando-observers)
     - [Integrações ActiveRecord e ActiveModel](#integrações-activerecord-e-activemodel)
       - [`.notify_observers_on()`](#notify_observers_on)
+      - [`.notify_observers_event()`](#notify_observers_event)
       - [`.notify_observers()`](#notify_observers)
   - [Desenvolvimento](#desenvolvimento)
   - [Contribuindo](#contribuindo)
@@ -553,7 +554,11 @@ end
 # Title: Hello world (de: exemplo # 6)
 ```
 
-Você também pode vincular os *observers* ao modelo **no nível da classe** com `with:`, evitando ter que chamar `attach` em cada instância. Use `context:` para encaminhar um contexto para esses *observers*, e passe qualquer opção extra (por exemplo, `on:`) diretamente para o callback subjacente.
+[⬆️ Voltar para o índice](#índice-)
+
+#### `.notify_observers_event()`
+
+Enquanto o `notify_observers_on` apenas conecta o callback a um broadcast (você ainda precisa chamar `attach` em cada instância), o `notify_observers_event` também **vincula os *observers* ao modelo no nível da classe** através da opção obrigatória `with:` — assim você nunca chama `observers.attach`. Use `context:` para encaminhar um contexto para esses *observers*, e passe qualquer opção extra (por exemplo, `on:`) diretamente para o callback subjacente.
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -561,7 +566,7 @@ class Post < ActiveRecord::Base
 
   # Anexa TitlePrinter (e TitlePrinterWithContext) em todo after_commit
   # disparado por um update — sem precisar de `observers.attach` por instância.
-  notify_observers_on(
+  notify_observers_event(
     :after_commit,
     with: [TitlePrinter, TitlePrinterWithContext],
     context: { from: 'class-level' },
@@ -585,7 +590,7 @@ Post.transaction { post.update(title: 'Hello again') }
 # Title: Hello again (de: class-level)
 ```
 
-> **Nota**: `with:` aceita um único *observer* ou um array. Sem ele, o `notify_observers_on` mantém seu comportamento original (apenas conecta o callback a um broadcast; você anexa os *observers* por instância).
+> **Nota**: `with:` aceita um único *observer* ou um array, e é obrigatório (sem *observers* para anexar, use o `notify_observers_on`).
 
 [⬆️ Voltar para o índice](#índice-)
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -59,7 +59,7 @@ Por causa desse problema, decidi criar uma gem que encapsula o padrão sem alter
     - [Desanexando observers](#desanexando-observers)
     - [Integrações ActiveRecord e ActiveModel](#integrações-activerecord-e-activemodel)
       - [`.notify_observers_on()`](#notify_observers_on)
-      - [`.notify_observers_event()`](#notify_observers_event)
+      - [`.notify_observers!()`](#anexando-observers-no-nível-da-classe-notify_observers)
       - [`.notify_observers()`](#notify_observers)
   - [Desenvolvimento](#desenvolvimento)
   - [Contribuindo](#contribuindo)
@@ -556,9 +556,9 @@ end
 
 [⬆️ Voltar para o índice](#índice-)
 
-#### `.notify_observers_event()`
+#### Anexando observers no nível da classe (`.notify_observers!()`)
 
-Enquanto o `notify_observers_on` apenas conecta o callback a um broadcast (você ainda precisa chamar `attach` em cada instância), o `notify_observers_event` também **vincula os *observers* ao modelo no nível da classe** através da opção obrigatória `with:` — assim você nunca chama `observers.attach`. Use `context:` para encaminhar um contexto para esses *observers*, e passe qualquer opção extra (por exemplo, `on:`) diretamente para o callback subjacente.
+Enquanto o `notify_observers_on` apenas conecta o callback a um broadcast (você ainda precisa chamar `attach` em cada instância), o `notify_observers!` também **vincula os *observers* ao modelo no nível da classe** através da opção obrigatória `with:` — assim você nunca chama `observers.attach`. A opção `event:` nomeia o callback a ser usado; use `context:` para encaminhar um contexto para esses *observers*, e passe qualquer opção extra (por exemplo, `on:`) diretamente para o callback subjacente.
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -566,11 +566,11 @@ class Post < ActiveRecord::Base
 
   # Anexa TitlePrinter (e TitlePrinterWithContext) em todo after_commit
   # disparado por um update — sem precisar de `observers.attach` por instância.
-  notify_observers_event(
-    :after_commit,
+  notify_observers!(
+    on: :update,
     with: [TitlePrinter, TitlePrinterWithContext],
-    context: { from: 'class-level' },
-    on: :update
+    event: :after_commit,
+    context: { from: 'class-level' }
   )
 
   # Equivalente a:
@@ -590,7 +590,7 @@ Post.transaction { post.update(title: 'Hello again') }
 # Title: Hello again (de: class-level)
 ```
 
-> **Nota**: `with:` aceita um único *observer* ou um array, e é obrigatório (sem *observers* para anexar, use o `notify_observers_on`).
+> **Nota**: `event:` e `with:` são obrigatórios (`with:` aceita um único *observer* ou um array). Sem *observers* para anexar, use o `notify_observers_on`.
 
 [⬆️ Voltar para o índice](#índice-)
 

--- a/lib/micro/observers/for/active_model.rb
+++ b/lib/micro/observers/for/active_model.rb
@@ -17,27 +17,33 @@ module Micro
             notify_observers!(Event::Names.fetch(events))
           end
 
-          def notify_observers_on(*callback_methods, with: nil, context: nil, **callback_options)
+          def notify_observers_on(*callback_methods)
+            Utils::Arrays.fetch_from_args(callback_methods).each do |callback_method|
+              self.public_send(callback_method, &notify_observers!([callback_method]))
+            end
+          end
+
+          NO_OBSERVERS_TO_NOTIFY_EVENT_MSG =
+            'no observers (expected at least one observer in `with:`)'.freeze
+
+          def notify_observers_event(*events, with:, context: nil, **callback_options)
             observers = Utils::Arrays.flatten_and_compact(with)
 
-            Utils::Arrays.fetch_from_args(callback_methods).each do |callback_method|
-              callback_block =
-                if observers.empty?
-                  notify_observers!([callback_method])
-                else
-                  attach_and_notify_observers!(callback_method, observers, context)
-                end
+            raise ArgumentError, NO_OBSERVERS_TO_NOTIFY_EVENT_MSG if observers.empty?
+
+            Utils::Arrays.fetch_from_args(events).each do |event|
+              callback_block = attach_and_notify_observers!(event, observers, context)
 
               if callback_options.empty?
-                self.public_send(callback_method, &callback_block)
+                self.public_send(event, &callback_block)
               else
-                self.public_send(callback_method, **callback_options, &callback_block)
+                self.public_send(event, **callback_options, &callback_block)
               end
             end
           end
 
-          def attach_and_notify_observers!(callback_method, observers, context)
-            events = [callback_method]
+          def attach_and_notify_observers!(event, observers, context)
+            events = [event]
 
             proc do |object|
               set = object.observers
@@ -48,6 +54,8 @@ module Micro
               set.send(:broadcast_if_subject_changed, events)
             end
           end
+
+          private_constant :NO_OBSERVERS_TO_NOTIFY_EVENT_MSG
         end
 
         def self.included(base)

--- a/lib/micro/observers/for/active_model.rb
+++ b/lib/micro/observers/for/active_model.rb
@@ -6,7 +6,7 @@ module Micro
 
       module ActiveModel
         module ClassMethods
-          def notify_observers!(events)
+          def notify_observers_proc(events)
             proc do |object|
               object.observers.subject_changed!
               object.observers.send(:broadcast_if_subject_changed, events)
@@ -14,35 +14,42 @@ module Micro
           end
 
           def notify_observers(*events)
-            notify_observers!(Event::Names.fetch(events))
+            notify_observers_proc(Event::Names.fetch(events))
           end
 
           def notify_observers_on(*callback_methods)
             Utils::Arrays.fetch_from_args(callback_methods).each do |callback_method|
-              self.public_send(callback_method, &notify_observers!([callback_method]))
+              self.public_send(callback_method, &notify_observers_proc([callback_method]))
             end
           end
 
-          NO_OBSERVERS_TO_NOTIFY_EVENT_MSG =
+          NO_OBSERVERS_TO_NOTIFY_MSG =
             'no observers (expected at least one observer in `with:`)'.freeze
 
-          def notify_observers_event(*events, with:, context: nil, **callback_options)
+          NO_EVENT_TO_NOTIFY_MSG =
+            'no event (expected a callback name in `event:`)'.freeze
+
+          def notify_observers!(event:, with:, context: nil, **callback_options)
             observers = Utils::Arrays.flatten_and_compact(with)
 
-            raise ArgumentError, NO_OBSERVERS_TO_NOTIFY_EVENT_MSG if observers.empty?
+            raise ArgumentError, NO_OBSERVERS_TO_NOTIFY_MSG if observers.empty?
 
-            Utils::Arrays.fetch_from_args(events).each do |event|
-              callback_block = attach_and_notify_observers!(event, observers, context)
+            events = Utils::Arrays.flatten_and_compact(event)
+
+            raise ArgumentError, NO_EVENT_TO_NOTIFY_MSG if events.empty?
+
+            events.each do |callback_method|
+              callback_block = attach_and_notify_observers_proc(callback_method, observers, context)
 
               if callback_options.empty?
-                self.public_send(event, &callback_block)
+                self.public_send(callback_method, &callback_block)
               else
-                self.public_send(event, **callback_options, &callback_block)
+                self.public_send(callback_method, **callback_options, &callback_block)
               end
             end
           end
 
-          def attach_and_notify_observers!(event, observers, context)
+          def attach_and_notify_observers_proc(event, observers, context)
             events = [event]
 
             proc do |object|
@@ -55,12 +62,12 @@ module Micro
             end
           end
 
-          private_constant :NO_OBSERVERS_TO_NOTIFY_EVENT_MSG
+          private_constant :NO_OBSERVERS_TO_NOTIFY_MSG, :NO_EVENT_TO_NOTIFY_MSG
         end
 
         def self.included(base)
           base.extend(ClassMethods)
-          base.send(:private_class_method, :notify_observers!, :attach_and_notify_observers!)
+          base.send(:private_class_method, :notify_observers_proc, :attach_and_notify_observers_proc)
           base.send(:include, ::Micro::Observers)
         end
       end

--- a/lib/micro/observers/for/active_model.rb
+++ b/lib/micro/observers/for/active_model.rb
@@ -17,16 +17,42 @@ module Micro
             notify_observers!(Event::Names.fetch(events))
           end
 
-          def notify_observers_on(*callback_methods)
+          def notify_observers_on(*callback_methods, with: nil, context: nil, **callback_options)
+            observers = Utils::Arrays.flatten_and_compact(with)
+
             Utils::Arrays.fetch_from_args(callback_methods).each do |callback_method|
-              self.public_send(callback_method, &notify_observers!([callback_method]))
+              callback_block =
+                if observers.empty?
+                  notify_observers!([callback_method])
+                else
+                  attach_and_notify_observers!(callback_method, observers, context)
+                end
+
+              if callback_options.empty?
+                self.public_send(callback_method, &callback_block)
+              else
+                self.public_send(callback_method, **callback_options, &callback_block)
+              end
+            end
+          end
+
+          def attach_and_notify_observers!(callback_method, observers, context)
+            events = [callback_method]
+
+            proc do |object|
+              set = object.observers
+
+              context ? set.attach(*observers, context: context) : set.attach(*observers)
+
+              set.subject_changed!
+              set.send(:broadcast_if_subject_changed, events)
             end
           end
         end
 
         def self.included(base)
           base.extend(ClassMethods)
-          base.send(:private_class_method, :notify_observers!)
+          base.send(:private_class_method, :notify_observers!, :attach_and_notify_observers!)
           base.send(:include, ::Micro::Observers)
         end
       end

--- a/lib/micro/observers/for/active_model.rb
+++ b/lib/micro/observers/for/active_model.rb
@@ -39,27 +39,92 @@ module Micro
             raise ArgumentError, NO_EVENT_TO_NOTIFY_MSG if events.empty?
 
             events.each do |callback_method|
-              callback_block = attach_and_notify_observers_proc(callback_method, observers, context)
+              register_observers_to_notify(callback_method, observers, context)
 
-              if callback_options.empty?
-                self.public_send(callback_method, &callback_block)
-              else
-                self.public_send(callback_method, **callback_options, &callback_block)
-              end
+              install_observers_to_notify_callback(callback_method, callback_options)
             end
           end
 
-          def attach_and_notify_observers_proc(event, observers, context)
-            events = [event]
-
-            proc do |object|
-              set = object.observers
-
-              context ? set.attach(*observers, context: context) : set.attach(*observers)
-
-              set.subject_changed!
-              set.send(:broadcast_if_subject_changed, events)
+          # Introspection: the observers declared via `notify_observers!`, keyed
+          # by the callback they fire on. e.g. { after_commit: [TitlePrinter] }
+          def observers_to_notify
+            __observers_to_notify.each_with_object({}) do |(event, entries), result|
+              result[event] = entries.map { |observer, _context| observer } unless entries.empty?
             end
+          end
+
+          # Remove previously declared observers. Without `from:` they are
+          # removed from every callback; pass `from:` (a callback name or an
+          # array of them) to scope it. With no observers, clears the callback(s).
+          def detach_observers_to_notify(*observers, from: nil)
+            observers = Utils::Arrays.flatten_and_compact(observers)
+            events = from ? Utils::Arrays.flatten_and_compact(from) : __observers_to_notify.keys
+
+            events.each do |event|
+              entries = __observers_to_notify[event]
+
+              next unless entries
+
+              if observers.empty?
+                __observers_to_notify.delete(event)
+              else
+                entries.reject! { |observer, _context| observers.include?(observer) }
+                __observers_to_notify.delete(event) if entries.empty?
+              end
+            end
+
+            observers_to_notify
+          end
+
+          def register_observers_to_notify(event, observers, context)
+            entries = (__observers_to_notify[event] ||= [])
+
+            observers.each do |observer|
+              entries << [observer, context] unless entries.any? { |existing, _| existing == observer }
+            end
+          end
+
+          def install_observers_to_notify_callback(event, callback_options)
+            installed = __observers_to_notify_callbacks
+
+            return if installed[event]
+
+            installed[event] = true
+
+            declaring_class = self
+
+            callback_block = proc do |record|
+              declaring_class.send(:notify_registered_observers, record, event)
+            end
+
+            if callback_options.empty?
+              self.public_send(event, &callback_block)
+            else
+              self.public_send(event, **callback_options, &callback_block)
+            end
+          end
+
+          def notify_registered_observers(record, event)
+            entries = __observers_to_notify[event]
+
+            return if entries.nil? || entries.empty?
+
+            set = record.observers
+
+            entries.each do |observer, context|
+              context ? set.attach(observer, context: context) : set.attach(observer)
+            end
+
+            set.subject_changed!
+            set.send(:broadcast_if_subject_changed, [event])
+          end
+
+          def __observers_to_notify
+            @__observers_to_notify ||= {}
+          end
+
+          def __observers_to_notify_callbacks
+            @__observers_to_notify_callbacks ||= {}
           end
 
           private_constant :NO_OBSERVERS_TO_NOTIFY_MSG, :NO_EVENT_TO_NOTIFY_MSG
@@ -67,7 +132,15 @@ module Micro
 
         def self.included(base)
           base.extend(ClassMethods)
-          base.send(:private_class_method, :notify_observers_proc, :attach_and_notify_observers_proc)
+          base.send(
+            :private_class_method,
+            :notify_observers_proc,
+            :register_observers_to_notify,
+            :install_observers_to_notify_callback,
+            :notify_registered_observers,
+            :__observers_to_notify,
+            :__observers_to_notify_callbacks
+          )
           base.send(:include, ::Micro::Observers)
         end
       end

--- a/test/micro/observers/for/active_record_test.rb
+++ b/test/micro/observers/for/active_record_test.rb
@@ -64,13 +64,14 @@ if ACTIVERECORD_AVAILABLE
       )
     end
 
-    # Declarative form: bind the observers to the model at the class level via
-    # `with:`, so callers no longer need to `attach` them on every instance.
+    # Declarative form: `notify_observers_event` binds the observers to the
+    # model at the class level via `with:`, so callers no longer need to
+    # `attach` them on every instance.
 
     class Law < ActiveRecord::Base
       include ::Micro::Observers::For::ActiveRecord
 
-      notify_observers_on(:after_commit, with: TitlePrinter)
+      notify_observers_event(:after_commit, with: TitlePrinter)
     end
 
     def test_observers_declared_at_the_class_level
@@ -82,7 +83,7 @@ if ACTIVERECORD_AVAILABLE
     class Album < ActiveRecord::Base
       include ::Micro::Observers::For::ActiveRecord
 
-      notify_observers_on(
+      notify_observers_event(
         :after_commit,
         with: [TitlePrinter, TitlePrinterWithContext],
         context: { from: 'studio' },
@@ -107,6 +108,20 @@ if ACTIVERECORD_AVAILABLE
           'Title: Baz, from: studio'
         ], MemoryOutput.history
       )
+    end
+
+    def test_notify_observers_event_requires_observers
+      error = assert_raises(ArgumentError) do
+        Class.new(ActiveRecord::Base) do
+          self.table_name = 'laws'
+
+          include ::Micro::Observers::For::ActiveRecord
+
+          notify_observers_event(:after_commit, with: nil)
+        end
+      end
+
+      assert_equal('no observers (expected at least one observer in `with:`)', error.message)
     end
   end
 end

--- a/test/micro/observers/for/active_record_test.rb
+++ b/test/micro/observers/for/active_record_test.rb
@@ -123,5 +123,61 @@ if ACTIVERECORD_AVAILABLE
 
       assert_equal('no observers (expected at least one observer in `with:`)', error.message)
     end
+
+    # The class-level observers are introspectable and detachable.
+
+    def test_class_level_observers_are_introspectable
+      assert_equal({ after_commit: [TitlePrinter] }, Law.observers_to_notify)
+
+      assert_equal(
+        { after_commit: [TitlePrinter, TitlePrinterWithContext] },
+        Album.observers_to_notify
+      )
+    end
+
+    def test_class_level_observers_are_detachable
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = 'albums'
+
+        include ::Micro::Observers::For::ActiveRecord
+
+        notify_observers!(
+          on: :update,
+          with: [TitlePrinter, TitlePrinterWithContext],
+          event: :after_commit,
+          context: { from: 'studio' }
+        )
+      end
+
+      assert_equal(
+        { after_commit: [TitlePrinter, TitlePrinterWithContext] },
+        klass.observers_to_notify
+      )
+
+      assert_equal({ after_commit: [TitlePrinter] }, klass.detach_observers_to_notify(TitlePrinterWithContext))
+
+      record = nil
+      klass.transaction { record = klass.create(title: 'Bar') }
+      klass.transaction { record.update(title: 'Baz') }
+
+      # Only TitlePrinter remains attached, so TitlePrinterWithContext is silent.
+      assert_equal(['Title: Baz'], MemoryOutput.history)
+    end
+
+    def test_detaching_every_observer_from_a_callback
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = 'laws'
+
+        include ::Micro::Observers::For::ActiveRecord
+
+        notify_observers!(event: :after_commit, with: TitlePrinter)
+      end
+
+      assert_equal({}, klass.detach_observers_to_notify(from: :after_commit))
+
+      klass.transaction { klass.create(title: 'Foo') }
+
+      assert_equal([], MemoryOutput.history)
+    end
   end
 end

--- a/test/micro/observers/for/active_record_test.rb
+++ b/test/micro/observers/for/active_record_test.rb
@@ -63,5 +63,50 @@ if ACTIVERECORD_AVAILABLE
         ], MemoryOutput.history
       )
     end
+
+    # Declarative form: bind the observers to the model at the class level via
+    # `with:`, so callers no longer need to `attach` them on every instance.
+
+    class Law < ActiveRecord::Base
+      include ::Micro::Observers::For::ActiveRecord
+
+      notify_observers_on(:after_commit, with: TitlePrinter)
+    end
+
+    def test_observers_declared_at_the_class_level
+      Law.transaction { Law.create(title: 'Foo') }
+
+      assert_equal(['Title: Foo'], MemoryOutput.history)
+    end
+
+    class Album < ActiveRecord::Base
+      include ::Micro::Observers::For::ActiveRecord
+
+      notify_observers_on(
+        :after_commit,
+        with: [TitlePrinter, TitlePrinterWithContext],
+        context: { from: 'studio' },
+        on: :update
+      )
+    end
+
+    def test_class_level_observers_with_context_and_a_callback_option
+      album = nil
+
+      # `on: :update` is forwarded to the AR callback, so create notifies nothing.
+      Album.transaction { album = Album.create(title: 'Bar') }
+
+      assert_equal([], MemoryOutput.history)
+
+      Album.transaction { album.update(title: 'Baz') }
+
+      # `context:` reaches the observers — TitlePrinterWithContext sees `from: studio`.
+      assert_equal(
+        [
+          'Title: Baz',
+          'Title: Baz, from: studio'
+        ], MemoryOutput.history
+      )
+    end
   end
 end

--- a/test/micro/observers/for/active_record_test.rb
+++ b/test/micro/observers/for/active_record_test.rb
@@ -64,14 +64,14 @@ if ACTIVERECORD_AVAILABLE
       )
     end
 
-    # Declarative form: `notify_observers_event` binds the observers to the
-    # model at the class level via `with:`, so callers no longer need to
-    # `attach` them on every instance.
+    # Declarative form: `notify_observers!` binds the observers to the model at
+    # the class level via `with:`, so callers no longer need to `attach` them on
+    # every instance.
 
     class Law < ActiveRecord::Base
       include ::Micro::Observers::For::ActiveRecord
 
-      notify_observers_event(:after_commit, with: TitlePrinter)
+      notify_observers!(event: :after_commit, with: TitlePrinter)
     end
 
     def test_observers_declared_at_the_class_level
@@ -83,11 +83,11 @@ if ACTIVERECORD_AVAILABLE
     class Album < ActiveRecord::Base
       include ::Micro::Observers::For::ActiveRecord
 
-      notify_observers_event(
-        :after_commit,
+      notify_observers!(
+        on: :update,
         with: [TitlePrinter, TitlePrinterWithContext],
-        context: { from: 'studio' },
-        on: :update
+        event: :after_commit,
+        context: { from: 'studio' }
       )
     end
 
@@ -110,14 +110,14 @@ if ACTIVERECORD_AVAILABLE
       )
     end
 
-    def test_notify_observers_event_requires_observers
+    def test_notify_observers_bang_requires_observers
       error = assert_raises(ArgumentError) do
         Class.new(ActiveRecord::Base) do
           self.table_name = 'laws'
 
           include ::Micro::Observers::For::ActiveRecord
 
-          notify_observers_event(:after_commit, with: nil)
+          notify_observers!(event: :after_commit, with: nil)
         end
       end
 

--- a/test/support.rb
+++ b/test/support.rb
@@ -13,6 +13,14 @@ if ACTIVERECORD_AVAILABLE
     create_table :books do |t|
       t.column :title, :string
     end
+
+    create_table :laws do |t|
+      t.column :title, :string
+    end
+
+    create_table :albums do |t|
+      t.column :title, :string
+    end
   end
 end
 


### PR DESCRIPTION
Adds a dedicated, backward-compatible class method for binding observers to an ActiveRecord/ActiveModel model **at the class level** — a better-ergonomics revival of the old [`idea_attach_observers_in_ar_callbacks`](https://github.com/serradura/u-observers/tree/idea_attach_observers_in_ar_callbacks) WIP (2020).

```ruby
class Post < ActiveRecord::Base
  include ::Micro::Observers::For::ActiveRecord

  notify_observers!(
    on: :update,
    with: [TitlePrinter, TitlePrinterWithContext],
    event: :after_commit,
    context: { from: 'class-level' }
  )
end
```

When the callback fires it attaches the declared observers (with the optional `context:`), marks the subject changed, and broadcasts an event named after the callback — so the observers implement `def self.after_commit(record[, event])`, exactly like with `notify_observers_on`. No per-instance `observers.attach` needed.

### Options
- `event:` (**required**) — the AR/AM callback to hook (e.g. `:after_commit`); also the event name broadcast to the observers. Accepts one symbol or an array.
- `with:` (**required**) — the observer(s) to attach class-wide (single object or array). Empty/missing raises a clear `ArgumentError`.
- `context:` — forwarded to the attached observers (the capability the old WIP dropped — context-aware observers no longer get `nil`).
- any extra kwargs (e.g. `on:`, `if:`, `unless:`) — passed straight through to the underlying callback.

### Introspectable & detachable
The declared observers live in a per-class registry keyed by callback, and the installed callback reads that registry at fire time — so they're queryable and removable at runtime:

```ruby
Post.observers_to_notify
# { after_commit: [TitlePrinter, TitlePrinterWithContext] }

Post.detach_observers_to_notify(TitlePrinterWithContext)   # from every callback
# { after_commit: [TitlePrinter] }

Post.detach_observers_to_notify(TitlePrinter, from: :after_commit)   # scoped
# {}

Post.detach_observers_to_notify(from: :after_commit)   # no observers -> clear the callback
```

The AR/AM callback is installed once per event (tracked separately), so re-declaring or detaching never double-installs it; a detached/empty event is just a no-op when it fires.

### The three methods, cleanly separated
| method | registers a callback? | attaches observers? |
|---|---|---|
| `notify_observers(*events)` | no (returns a broadcast proc) | no |
| `notify_observers_on(*callbacks)` | yes | no — you `attach` per instance |
| `notify_observers!(event:, with:)` | yes | **yes — class-level, introspectable & detachable** |

### Design notes
- **All-keyword**, so there's no positional/`on:` "double on" (the earlier `notify_observers_on(..., on: :update)` had `_on` colliding with AR's `on:` filter).
- **Dedicated method, not an overload** — `notify_observers` and `notify_observers_on` are left untouched.
- **Naming**: `!` was chosen deliberately. Heads-up carried from review: `!` elsewhere in the gem (`Set#notify!` / `call!`) means "broadcast unconditionally"; here it reads as the declarative setup macro. The previously-private `notify_observers!` proc-builder was renamed (`notify_observers_proc`) to free the name.

### Compatibility
- `notify_observers` and `notify_observers_on` are unchanged. The feature is purely additive — honors the no-breaking-changes policy.
- Re-attaching on a repeatedly-firing callback is a no-op (`Subscribers#attach` dedupes by observer identity).

### Verified
- Ruby 2.7.8 / Rails 6.0 & 7.1 → 42 runs, 0 failures
- Ruby 4.0.1 / Rails 8.1 & edge → 42 runs, 0 failures
- Tests cover class-level binding (no per-instance attach), `context:` + `on: :update` behavior, the required-`with:` guard, and the introspection/detach API.

### Docs
`README.md` and `README.pt-BR.md` both get a dedicated section for `.notify_observers!()` (incl. the introspection/detach API) + TOC entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)