### PR TITLE
docs: add CHANGELOG.md (Keep a Changelog) and point gemspec at it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,166 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Per the project's stability policy, a major version bump signals only that a
+Ruby or Rails version was dropped from the supported matrix — a dependency-floor
+change, not a behavior break.
+
+## [Unreleased]
+
+### Added
+
+- `notify_observers!` — declare observers on an `ActiveModel`/`ActiveRecord`
+  model **at the class level**, so they no longer need to be attached on every
+  instance. Takes `event:` (the callback to hook, also the broadcast event
+  name), `with:` (the observer(s) to attach), an optional `context:` forwarded
+  to those observers, and any extra option (e.g. `on:`) passed straight through
+  to the underlying callback.
+- `observers_to_notify` — introspect the observers declared via
+  `notify_observers!`, keyed by callback.
+- `detach_observers_to_notify(*observers, from: nil)` — remove declared
+  observers from a callback (or from all of them); with no observers it clears
+  the callback entirely.
+
+### Changed
+
+- Raised the supported floor to **Ruby >= 2.7** (was `>= 2.2`) and
+  **ActiveRecord/Rails >= 6.0** (was `>= 3.2`).
+- Modernized CI/test setup: the suite now runs on Ruby 2.7 through 4.0 + head
+  against Rails 6.0 through 8.1 + edge via [Appraisal](https://github.com/thoughtbot/appraisal),
+  with a no-`activerecord` baseline run.
+
+## [2.3.0] - 2020-11-25
+
+### Added
+
+- Allow defining observers using blocks (e.g. `after_commit(&notify_observers(:event))`).
+
+## [2.2.1] - 2020-11-18
+
+### Fixed
+
+- `observers.once()` when its callable returns `nil`.
+
+## [2.2.0] - 2020-11-18
+
+### Added
+
+- `Observers::Set#once` and `Observers::Set#off`.
+- Allow defining multiple callables for the same event.
+- `Observers::Set#include?` (with `included?` kept as an alias).
+
+### Fixed
+
+- Observer deletion when it must be performed only once.
+- `Observers::Set#inspect`.
+
+## [2.1.0] - 2020-10-16
+
+### Added
+
+- Allow defining callable observers with a context.
+- Portuguese documentation ([`README.pt-BR.md`](https://github.com/serradura/u-observers/blob/main/README.pt-BR.md)).
+
+## [2.0.0] - 2020-10-06
+
+### Added
+
+- `Micro::Observers::Event` to represent the notification payload.
+
+### Changed
+
+- Renamed `Micro::Observers::Manager` to `Micro::Observers::Set`.
+- Transformed `Micro::Observers::Events` into `Micro::Observers::Event::Names`.
+- `subject_changed` methods now return booleans.
+
+## [1.0.0] - 2020-10-05
+
+### Added
+
+- `Micro::Observers::For::ActiveModel` and `Micro::Observers::For::ActiveRecord`
+  integrations (`notify_observers_on`, `notify_observers`).
+- `call!` and `notify!` to broadcast even when the subject hasn't been changed.
+- `Micro::Observers::Manager#inspect`.
+
+## [0.9.0] - 2020-09-29
+
+### Added
+
+- CI running against multiple Ruby and ActiveRecord versions.
+
+### Changed
+
+- Added `subject_changed` to ensure idempotency of notifications.
+
+### Removed
+
+- The concept of "actions".
+
+## [0.8.0] - 2020-09-28
+
+### Changed
+
+- Resolve a callable observer's argument only when the observer is executed.
+
+## [0.7.0] - 2020-09-26
+
+### Added
+
+- Attach and detach multiple observers at once.
+
+## [0.6.0] - 2020-09-26
+
+### Changed
+
+- Optimized `Micro::Observers::Manager#notify` and `#call`.
+
+## [0.5.0] - 2020-09-26
+
+### Changed
+
+- Normalized the class and instance methods.
+
+## [0.4.0] - 2020-09-25
+
+### Added
+
+- Notify events and call actions.
+
+## [0.3.0] - 2020-09-25
+
+### Added
+
+- `Micro::Observers#on`.
+
+## [0.2.0] - 2020-09-25
+
+### Changed
+
+- `Micro::Observers::Manager` receives the subject through its constructor.
+
+## [0.1.0] - 2020-09-25
+
+### Added
+
+- Initial release — the `Micro::Observers` implementation of the observer pattern.
+
+[Unreleased]: https://github.com/serradura/u-observers/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/serradura/u-observers/compare/v2.2.1...v2.3.0
+[2.2.1]: https://github.com/serradura/u-observers/compare/v2.2.0...v2.2.1
+[2.2.0]: https://github.com/serradura/u-observers/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/serradura/u-observers/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/serradura/u-observers/compare/v1.0.0...v2.0.0
+[1.0.0]: https://github.com/serradura/u-observers/compare/v0.9.0...v1.0.0
+[0.9.0]: https://github.com/serradura/u-observers/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/serradura/u-observers/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/serradura/u-observers/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/serradura/u-observers/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/serradura/u-observers/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/serradura/u-observers/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/serradura/u-observers/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/serradura/u-observers/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/serradura/u-observers/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,30 +122,35 @@ Running the matrix locally (multiple Rubies via mise, see `.tool-versions`):
 - Pin a 2.x bundler per Ruby when needed: bare `bundle` can grab an incompatible
   4.x on Ruby 3.1 (and 2.7/3.0 need bundler `2.4.22`, as CI does).
 
-## README is part of every change
+## CHANGELOG and READMEs are part of every change
 
-Both READMEs are user-facing and **must stay in sync with each other**:
+These user-facing files must stay in sync with the code:
 
-- **`README.md`** (English) and **`README.pt-BR.md`** (Portuguese) — any
-  documented-API or compatibility change goes into **both** in the same commit.
-- The **Compatibility** table near the top references the supported Ruby ×
-  ActiveRecord bounds. Update it when the matrix moves.
-- If you change a documented API, update the relevant Usage section (and its
+- **`CHANGELOG.md`**: follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
+  Every user-visible change (new API, behavior change, dep bump that shifts the
+  supported matrix, fix, security fix) gets a bullet under the appropriate
+  section (`Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` /
+  `Security`) in `[Unreleased]`. Pure README/CI/internal-refactor changes
+  generally don't need an entry. The gemspec `changelog_uri` points here.
+- **`README.md`** (English) and **`README.pt-BR.md`** (Portuguese) **must stay
+  in sync with each other** — any documented-API or compatibility change goes
+  into **both** in the same commit. The **Compatibility** table references the
+  supported Ruby × ActiveRecord bounds; update it when the matrix moves. If you
+  change a documented API, update the relevant Usage section (and its
   table-of-contents entry) in both files.
-
-There is no `CHANGELOG.md` in this repo — release notes live in
-[GitHub Releases](https://github.com/serradura/u-observers/releases) (the
-gemspec `changelog_uri` points there).
 
 ## Bumping the version
 
 1. Edit `lib/micro/observers/version.rb` — change `Micro::Observers::VERSION`.
    Follow [SemVer](https://semver.org/): patch for fixes, minor for additive
    user-visible changes, major for breaking changes.
-2. Update the **Compatibility** table in `README.md` and `README.pt-BR.md`: if
+2. In `CHANGELOG.md`, turn `[Unreleased]` into a new `## [X.Y.Z] - YYYY-MM-DD`
+   section and add a matching compare link at the bottom
+   (`[X.Y.Z]: …/compare/vPREV...vX.Y.Z`).
+3. Update the **Compatibility** table in `README.md` and `README.pt-BR.md`: if
    supported Ruby / ActiveRecord bounds changed, add a new row; otherwise bump
    the existing row's version label.
-3. If the supported matrix moved, double-check that the Compatibility table, the
+4. If the supported matrix moved, double-check that the Compatibility table, the
    CI matrix (`.github/workflows/ci.yml`), and the `Appraisals` file all reflect
    the new bounds.
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,19 @@
 <p align="center">
   <h1 align="center">👀 μ-observers</h1>
   <p align="center"><i>Simple and powerful implementation of the observer pattern.</i></p>
-  <br>
 </p>
 
 <p align="center">
   <a href="https://rubygems.org/gems/u-observers">
     <img alt="Gem" src="https://img.shields.io/gem/v/u-observers.svg?style=flat-square">
   </a>
-
   <a href="https://github.com/serradura/u-observers/actions/workflows/ci.yml">
     <img alt="Build Status" src="https://github.com/serradura/u-observers/actions/workflows/ci.yml/badge.svg">
   </a>
-
-  <a href="https://qlty.sh/gh/serradura/projects/u-observers">
-    <img alt="Maintainability" src="https://qlty.sh/gh/serradura/projects/u-observers/maintainability.svg">
-  </a>
-
-  <a href="https://qlty.sh/gh/serradura/projects/u-observers">
-    <img alt="Code Coverage" src="https://qlty.sh/gh/serradura/projects/u-observers/coverage.svg">
-  </a>
-
-  <br>
-
+  <br/>
+  <a href="https://qlty.sh/gh/serradura/projects/u-observers"><img src="https://qlty.sh/gh/serradura/projects/u-observers/maintainability.svg" alt="Maintainability" /></a>
+  <a href="https://qlty.sh/gh/serradura/projects/u-observers"><img src="https://qlty.sh/gh/serradura/projects/u-observers/coverage.svg" alt="Code Coverage" /></a>
+  <br/>
   <img src="https://img.shields.io/badge/Ruby%20%3E%3D%202.7%2C%20%3C%3D%20Head-ruby.svg?colorA=444&colorB=333" alt="Ruby">
   <img src="https://img.shields.io/badge/Rails%20%3E%3D%206.0%2C%20%3C%3D%20Edge-rails.svg?colorA=444&colorB=333" alt="Rails">
 </p>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Because of this issue, I decided to create a gem that encapsulates the pattern w
 > **Note:** Você entende português? 🇧🇷&nbsp;🇵🇹 Verifique o [README traduzido em pt-BR](https://github.com/serradura/u-observers/blob/main/README.pt-BR.md).
 
 # Table of contents <!-- omit in toc -->
+
 - [Installation](#installation)
 - [Compatibility](#compatibility)
   - [Usage](#usage)
@@ -60,7 +61,7 @@ Because of this issue, I decided to create a gem that encapsulates the pattern w
     - [Detaching observers](#detaching-observers)
     - [ActiveRecord and ActiveModel integrations](#activerecord-and-activemodel-integrations)
       - [`.notify_observers_on()`](#notify_observers_on)
-      - [`.notify_observers!()`](#attaching-observers-at-the-class-level-notify_observers)
+      - [Attaching observers at the class level (`.notify_observers!()`)](#attaching-observers-at-the-class-level-notify_observers)
       - [`.notify_observers()`](#notify_observers)
   - [Development](#development)
   - [Contributing](#contributing)
@@ -77,11 +78,24 @@ gem 'u-observers'
 
 # Compatibility
 
-| u-observers | branch  | ruby     | activerecord  |
-| ----------- | ------- | -------- | ------------- |
-| unreleased  | main    | >= 2.7.0 | >= 6.0, <= Edge |
-| 2.3.0       | v2.x    | >= 2.2.0 | >= 3.2, < 6.1 |
-| 1.0.0       | v1.x    | >= 2.2.0 | >= 3.2, < 6.1 |
+| u-observers | branch | ruby     | activerecord    |
+| ----------- | ------ | -------- | --------------- |
+| unreleased  | main   | >= 2.7.0 | >= 6.0, <= Edge |
+| 2.3.0       | v2.x   | >= 2.2.0 | >= 3.2, < 6.1   |
+| 1.0.0       | v1.x   | >= 2.2.0 | >= 3.2, < 6.1   |
+
+This library is tested (CI matrix) against:
+
+| Ruby / Rails | 6.0 | 6.1 | 7.0 | 7.1 | 7.2 | 8.0 | 8.1 | Edge |
+| ------------ | --- | --- | --- | --- | --- | --- | --- | ---- |
+| 2.7          | ✅  | ✅  | ✅  | ✅  |     |     |     |      |
+| 3.0          | ✅  | ✅  | ✅  | ✅  |     |     |     |      |
+| 3.1          |     |     | ✅  | ✅  | ✅  |     |     |      |
+| 3.2          |     |     | ✅  | ✅  | ✅  | ✅  |     |      |
+| 3.3          |     |     | ✅  | ✅  | ✅  | ✅  | ✅  | ✅   |
+| 3.4          |     |     |     |     | ✅  | ✅  | ✅  | ✅   |
+| 4.x          |     |     |     |     |     |     | ✅  | ✅   |
+| Head         |     |     |     |     |     |     | ✅  | ✅   |
 
 > **Note**: The ActiveRecord isn't a dependency, but you could add a module to enable some static methods that were designed to be used with its [callbacks](https://guides.rubyonrails.org/active_record_callbacks.html).
 
@@ -243,6 +257,7 @@ The `observers.on()` method enables you to attach a callable as an observer.
 Usually, a callable has a well-defined responsibility (do only one thing), because of this, it tends to be more [SRP (Single-responsibility principle)](https://en.wikipedia.org/wiki/Single-responsibility_principle) friendly than a conventional observer (that could have N methods to respond to different kinds of notification).
 
 This method receives the below options:
+
 1. `:event` the expected event name.
 2. `:call` the callable object itself.
 3. `:with` (optional) it can define the value which will be used as the callable object's argument. So, if it is a `Proc`, a `Micro::Observers::Event` instance will be received as the `Proc` argument, and its output will be the callable argument. But if this option wasn't defined, the `Micro::Observers::Event` instance will be the callable argument.
@@ -507,6 +522,7 @@ order.observers.count # 0
 To make use of this feature you need to require an additional module.
 
 Gemfile example:
+
 ```ruby
 gem 'u-observers', require: 'u-observers/for/active_record'
 ```
@@ -612,7 +628,7 @@ Post.detach_observers_to_notify(from: :after_commit)
 
 #### `.notify_observers()`
 
-The `notify_observers` allows you to define one or more *events*, that will be used to notify after the execution of some `ActiveModel`/`ActiveRecord` callback.
+The `notify_observers` allows you to define one or more _events_, that will be used to notify after the execution of some `ActiveModel`/`ActiveRecord` callback.
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -661,7 +677,6 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/serradura/u-observers. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/serradura/u-observers/blob/master/CODE_OF_CONDUCT.md).
-
 
 ## License
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,28 +1,19 @@
 <p align="center">
   <h1 align="center">👀 μ-observers</h1>
   <p align="center"><i>Implementação simples e poderosa do padrão observer.</i></p>
-  <br>
 </p>
 
 <p align="center">
   <a href="https://rubygems.org/gems/u-observers">
     <img alt="Gem" src="https://img.shields.io/gem/v/u-observers.svg?style=flat-square">
   </a>
-
   <a href="https://github.com/serradura/u-observers/actions/workflows/ci.yml">
     <img alt="Build Status" src="https://github.com/serradura/u-observers/actions/workflows/ci.yml/badge.svg">
   </a>
-
-  <a href="https://qlty.sh/gh/serradura/projects/u-observers">
-    <img alt="Maintainability" src="https://qlty.sh/gh/serradura/projects/u-observers/maintainability.svg">
-  </a>
-
-  <a href="https://qlty.sh/gh/serradura/projects/u-observers">
-    <img alt="Code Coverage" src="https://qlty.sh/gh/serradura/projects/u-observers/coverage.svg">
-  </a>
-
-  <br>
-
+  <br/>
+  <a href="https://qlty.sh/gh/serradura/projects/u-observers"><img src="https://qlty.sh/gh/serradura/projects/u-observers/maintainability.svg" alt="Maintainability" /></a>
+  <a href="https://qlty.sh/gh/serradura/projects/u-observers"><img src="https://qlty.sh/gh/serradura/projects/u-observers/coverage.svg" alt="Code Coverage" /></a>
+  <br/>
   <img src="https://img.shields.io/badge/Ruby%20%3E%3D%202.7%2C%20%3C%3D%20Head-ruby.svg?colorA=444&colorB=333" alt="Ruby">
   <img src="https://img.shields.io/badge/Rails%20%3E%3D%206.0%2C%20%3C%3D%20Edge-rails.svg?colorA=444&colorB=333" alt="Rails">
 </p>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -59,7 +59,7 @@ Por causa desse problema, decidi criar uma gem que encapsula o padrão sem alter
     - [Desanexando observers](#desanexando-observers)
     - [Integrações ActiveRecord e ActiveModel](#integrações-activerecord-e-activemodel)
       - [`.notify_observers_on()`](#notify_observers_on)
-      - [`.notify_observers!()`](#anexando-observers-no-nível-da-classe-notify_observers)
+      - [Anexando observers no nível da classe (`.notify_observers!()`)](#anexando-observers-no-nível-da-classe-notify_observers)
       - [`.notify_observers()`](#notify_observers)
   - [Desenvolvimento](#desenvolvimento)
   - [Contribuindo](#contribuindo)
@@ -76,11 +76,24 @@ gem 'u-observers'
 
 # Compatibilidade
 
-| u-observers | branch  | ruby     | activerecord  |
-| ----------- | ------- | -------- | ------------- |
-| unreleased  | main    | >= 2.7.0 | >= 6.0, <= Edge |
-| 2.3.0       | v2.x    | >= 2.2.0 | >= 3.2, < 6.1 |
-| 1.0.0       | v1.x    | >= 2.2.0 | >= 3.2, < 6.1 |
+| u-observers | branch | ruby     | activerecord    |
+| ----------- | ------ | -------- | --------------- |
+| unreleased  | main   | >= 2.7.0 | >= 6.0, <= Edge |
+| 2.3.0       | v2.x   | >= 2.2.0 | >= 3.2, < 6.1   |
+| 1.0.0       | v1.x   | >= 2.2.0 | >= 3.2, < 6.1   |
+
+Esta biblioteca é testada (CI matrix) contra:
+
+| Ruby / Rails | 6.0 | 6.1 | 7.0 | 7.1 | 7.2 | 8.0 | 8.1 | Edge |
+| ------------ | --- | --- | --- | --- | --- | --- | --- | ---- |
+| 2.7          | ✅  | ✅  | ✅  | ✅  |     |     |     |      |
+| 3.0          | ✅  | ✅  | ✅  | ✅  |     |     |     |      |
+| 3.1          |     |     | ✅  | ✅  | ✅  |     |     |      |
+| 3.2          |     |     | ✅  | ✅  | ✅  | ✅  |     |      |
+| 3.3          |     |     | ✅  | ✅  | ✅  | ✅  | ✅  | ✅   |
+| 3.4          |     |     |     |     | ✅  | ✅  | ✅  | ✅   |
+| 4.x          |     |     |     |     |     |     | ✅  | ✅   |
+| Head         |     |     |     |     |     |     | ✅  | ✅   |
 
 > **Nota**: O ActiveRecord não é uma dependência, mas você pode adicionar um módulo para habilitar alguns métodos estáticos que foram projetados para serem usados ​​com seus [callbacks](https://guides.rubyonrails.org/active_record_callbacks.html).
 
@@ -167,7 +180,7 @@ order.observers.notify
 
 ### Compartilhando um contexto com seus observadores
 
-Para compartilhar um valor de contexto (qualquer tipo de objeto Ruby) com um ou mais observadores, você precisará usar a palavra-chave `:context` como o último argumento do  método `#attach`. Este recurso oferece a você uma oportunidade única de compartilhar um valor no momento de anexar um *observer*.
+Para compartilhar um valor de contexto (qualquer tipo de objeto Ruby) com um ou mais observadores, você precisará usar a palavra-chave `:context` como o último argumento do método `#attach`. Este recurso oferece a você uma oportunidade única de compartilhar um valor no momento de anexar um _observer_.
 
 Quando o método do observer receber dois argumentos, o primeiro será o sujeito e o segundo uma instância `Micro::Observers::Event` que terá o valor do contexto.
 
@@ -199,7 +212,7 @@ order.cancel!
 
 ### Compartilhando dados ao notificar os observadores
 
-Como mencionado anteriormente, o [`event context`](#compartilhando-um-contexto-com-seus-observadores) é um valor armazenado quando você anexa seu *observer*. Mas, às vezes, será útil enviar alguns dados adicionais ao transmitir um evento aos seus *observers*. O `event data` dá a você esta oportunidade única de compartilhar algum valor no momento da notificação.
+Como mencionado anteriormente, o [`event context`](#compartilhando-um-contexto-com-seus-observadores) é um valor armazenado quando você anexa seu _observer_. Mas, às vezes, será útil enviar alguns dados adicionais ao transmitir um evento aos seus _observers_. O `event data` dá a você esta oportunidade única de compartilhar algum valor no momento da notificação.
 
 ```ruby
 class Order
@@ -226,12 +239,13 @@ order.observers.notify(:changed, data: 1)
 ### O que é `Micro::Observers::Event`?
 
 O `Micro::Observers::Event` é o payload do evento. Veja abaixo todas as suas propriedades:
+
 - `#name` será o evento transmitido.
 - `#subject` será o sujeito observado.
-- `#context` serão [os dados de contexto](#compartilhando-um-contexto-com-seus-observadores) que foram definidos no momento em que você anexa o *observer*.
+- `#context` serão [os dados de contexto](#compartilhando-um-contexto-com-seus-observadores) que foram definidos no momento em que você anexa o _observer_.
 - `#data` será [o valor compartilhado na notificação dos observadores](#compartilhando-dados-ao-notificar-os-observadores).
 - `#ctx` é um apelido para o método `#context`.
-- `#subj` é um *alias* para o método `#subject`.
+- `#subj` é um _alias_ para o método `#subject`.
 
 [⬆️ Voltar para o índice](#índice-)
 
@@ -242,10 +256,11 @@ O método `observers.on()` permite que você anexe um callable (objeto que respo
 Normalmente, um callable tem uma responsabilidade bem definida (faz apenas uma coisa), por isso, tende a ser mais amigável com o [SRP (princípio de responsabilidade única)](https://en.wikipedia.org/wiki/Single-responsibility_principle) do que um observador convencional (que poderia ter N métodos para responder a diferentes tipos de notificação).
 
 Este método recebe as opções abaixo:
+
 1. `:event` o nome do evento esperado.
 2. `:call` o próprio callable.
 3. `:with` (opcional) pode definir o valor que será usado como argumento do objeto callable. Portanto, se for um `Proc`, uma instância de `Micro::Observers::Event` será recebida como o argumento `Proc` e sua saída será o argumento que pode ser chamado. Mas se essa opção não for definida, a instância `Micro::Observers::Event` será o argumento do callable.
-4. `:context` serão os dados de contexto que foram definidos no momento em que você anexa o *observer*.
+4. `:context` serão os dados de contexto que foram definidos no momento em que você anexa o _observer_.
 
 ```ruby
 class Person
@@ -289,7 +304,7 @@ person.name = 'Coutinho'
 
 ### Chamando os observadores
 
-Você pode usar um callable (uma classe, módulo ou objeto que responda ao método `call`) para ser seu *observer*. Para fazer isso, você só precisa usar o método `#call` em vez de `#notify`.
+Você pode usar um callable (uma classe, módulo ou objeto que responda ao método `call`) para ser seu _observer_. Para fazer isso, você só precisa usar o método `#call` em vez de `#notify`.
 
 ```ruby
 class Order
@@ -507,6 +522,7 @@ order.observers.count # 0
 Para fazer uso deste recurso, você precisa de um módulo adicional.
 
 Exemplo de Gemfile:
+
 ```ruby
 gem 'u-observers', require: 'u-observers/for/active_record'
 ```
@@ -515,7 +531,7 @@ Este recurso irá expor módulos que podem ser usados ​​para adicionar macro
 
 #### `.notify_observers_on()`
 
-O `notify_observers_on` permite que você defina um ou mais callbacks do `ActiveModel`/`ActiveRecord`, que serão usados ​​para notificar seus *observers*.
+O `notify_observers_on` permite que você defina um ou mais callbacks do `ActiveModel`/`ActiveRecord`, que serão usados ​​para notificar seus _observers_.
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -558,7 +574,7 @@ end
 
 #### Anexando observers no nível da classe (`.notify_observers!()`)
 
-Enquanto o `notify_observers_on` apenas conecta o callback a um broadcast (você ainda precisa chamar `attach` em cada instância), o `notify_observers!` também **vincula os *observers* ao modelo no nível da classe** através da opção obrigatória `with:` — assim você nunca chama `observers.attach`. A opção `event:` nomeia o callback a ser usado; use `context:` para encaminhar um contexto para esses *observers*, e passe qualquer opção extra (por exemplo, `on:`) diretamente para o callback subjacente.
+Enquanto o `notify_observers_on` apenas conecta o callback a um broadcast (você ainda precisa chamar `attach` em cada instância), o `notify_observers!` também **vincula os _observers_ ao modelo no nível da classe** através da opção obrigatória `with:` — assim você nunca chama `observers.attach`. A opção `event:` nomeia o callback a ser usado; use `context:` para encaminhar um contexto para esses _observers_, e passe qualquer opção extra (por exemplo, `on:`) diretamente para o callback subjacente.
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -590,9 +606,9 @@ Post.transaction { post.update(title: 'Hello again') }
 # Title: Hello again (de: class-level)
 ```
 
-> **Nota**: `event:` e `with:` são obrigatórios (`with:` aceita um único *observer* ou um array). Sem *observers* para anexar, use o `notify_observers_on`.
+> **Nota**: `event:` e `with:` são obrigatórios (`with:` aceita um único _observer_ ou um array). Sem _observers_ para anexar, use o `notify_observers_on`.
 
-Os *observers* declarados são inspecionáveis e removíveis no nível da classe:
+Os _observers_ declarados são inspecionáveis e removíveis no nível da classe:
 
 ```ruby
 Post.observers_to_notify

--- a/u-observers.gemspec
+++ b/u-observers.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/serradura/u-observers'
-  spec.metadata['changelog_uri'] = 'https://github.com/serradura/u-observers/releases'
+  spec.metadata['changelog_uri'] = 'https://github.com/serradura/u-observers/blob/main/CHANGELOG.md'
   spec.metadata['bug_tracker_uri'] = "#{spec.homepage}/issues"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
Adds a complete `CHANGELOG.md` and wires the gemspec to it.

### CHANGELOG.md
- Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) + SemVer.
- Reconstructed from the git tags `v0.1.0` → `v2.3.0` (15 releases, real dates), each with `Added`/`Changed`/`Removed`/`Fixed` entries derived from the history, and compare links for every version.
- `[Unreleased]` captures the work since 2.3.0:
  - **Added** — `notify_observers!` (+ `observers_to_notify` / `detach_observers_to_notify`).
  - **Changed** — raised the supported floor to Ruby >= 2.7 / Rails >= 6.0; Appraisal-based CI matrix.
- Kept as `[Unreleased]` (not stamped). Note: per the stability policy the Ruby/Rails floor raise makes the next release a **major** bump (3.0.0) — left for a human to cut.

### gemspec
- `changelog_uri` now points to `…/blob/main/CHANGELOG.md` (was the Releases page). `CHANGELOG.md` is packaged in the gem (`git ls-files`); gemspec validates.

### CLAUDE.md
- Updated: it previously said "there is no CHANGELOG.md". Now documents the changelog as part of every change and adds it to the version-bump steps.

### READMEs (EN + pt-BR)
- Added the "tested (CI matrix) against" Ruby/Rails grid, matched the `.notify_observers!()` TOC entry to its heading, and a markdown formatting pass.

Docs/metadata only — no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)