### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ change, not a behavior break.
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-06-01
+
 ### Added
 
 - `notify_observers!` — declare observers on an `ActiveModel`/`ActiveRecord`
@@ -148,7 +150,8 @@ change, not a behavior break.
 
 - Initial release — the `Micro::Observers` implementation of the observer pattern.
 
-[Unreleased]: https://github.com/u-gems/u-observers/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/u-gems/u-observers/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/u-gems/u-observers/compare/v2.3.0...v3.0.0
 [2.3.0]: https://github.com/u-gems/u-observers/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/u-gems/u-observers/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/u-gems/u-observers/compare/v2.1.0...v2.2.0

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ gem 'u-observers'
 
 | u-observers | branch | ruby     | activerecord    |
 | ----------- | ------ | -------- | --------------- |
-| unreleased  | main   | >= 2.7.0 | >= 6.0, <= Edge |
+| 3.0.0       | main   | >= 2.7.0 | >= 6.0, <= Edge |
 | 2.3.0       | v2.x   | >= 2.2.0 | >= 3.2, < 6.1   |
 | 1.0.0       | v1.x   | >= 2.2.0 | >= 3.2, < 6.1   |
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -69,7 +69,7 @@ gem 'u-observers'
 
 | u-observers | branch | ruby     | activerecord    |
 | ----------- | ------ | -------- | --------------- |
-| unreleased  | main   | >= 2.7.0 | >= 6.0, <= Edge |
+| 3.0.0       | main   | >= 2.7.0 | >= 6.0, <= Edge |
 | 2.3.0       | v2.x   | >= 2.2.0 | >= 3.2, < 6.1   |
 | 1.0.0       | v1.x   | >= 2.2.0 | >= 3.2, < 6.1   |
 

--- a/lib/micro/observers/version.rb
+++ b/lib/micro/observers/version.rb
@@ -1,5 +1,5 @@
 module Micro
   module Observers
-    VERSION = '2.3.0'
+    VERSION = '3.0.0'
   end
 end


### PR DESCRIPTION
## Summary

Bumps `u-observers` to **3.0.0**. The supported dependency floor was raised to **Ruby >= 2.7** and **ActiveRecord/Rails >= 6.0** — per the project's stability policy, a dropped Ruby/Rails version warrants a major bump (a dependency-floor change, not a behavior break).

## Changes

- `lib/micro/observers/version.rb` — `VERSION = '3.0.0'`
- `CHANGELOG.md` — cut `[Unreleased]` into `## [3.0.0] - 2026-06-01` and added the compare link
- `README.md` & `README.pt-BR.md` — bumped the Compatibility table row to `3.0.0`

The CI matrix and `Appraisals` already reflect the new bounds from the earlier floor-raise commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)